### PR TITLE
Cache the storage client

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -645,7 +645,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setTraceLogTimeThreshold(GCS_TRACE_LOG_TIME_THRESHOLD_MS.get(config, config::getLong))
         .setTraceLogExcludeProperties(
             ImmutableSet.copyOf(GCS_TRACE_LOG_EXCLUDE_PROPERTIES.getStringCollection(config)))
-        .setStorageClientCachingExperimentEnabled(GCS_STORAGE_CLIENT_CACHING_EXPERIMENT.get(config, config::getBoolean));
+        .setStorageClientCachingExperimentEnabled(
+            GCS_STORAGE_CLIENT_CACHING_EXPERIMENT.get(config, config::getBoolean));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -510,6 +510,15 @@ public class GoogleHadoopFileSystemConfiguration {
       new HadoopConfigurationProperty<>("fs.gs.client.upload.type", UploadType.CHUNK_UPLOAD);
 
   /**
+   * Configuration key to enable JAVA_STORAGE client caching across FS objects. This config will be
+   * effective only if fs.gs.client.type is set to STORAGE_CLIENT.
+   */
+  public static final HadoopConfigurationProperty<Boolean> GCS_STORAGE_CLIENT_CACHING_EXPERIMENT =
+      new HadoopConfigurationProperty<>(
+          "fs.gs.client.caching.experiment.enabled",
+          GoogleCloudStorageOptions.DEFAULT.isStorageClientCachingExperimentEnabled());
+
+  /**
    * Configuration key to configure the Path where uploads will be parked on disk. If not set then
    * uploads will be parked at default location pointed by java-storage client. This will only be
    * effective if fs.gs.client.upload.type is set to non-default value.
@@ -635,7 +644,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setOperationTraceLogEnabled(GCS_OPERATION_TRACE_LOG_ENABLE.get(config, config::getBoolean))
         .setTraceLogTimeThreshold(GCS_TRACE_LOG_TIME_THRESHOLD_MS.get(config, config::getLong))
         .setTraceLogExcludeProperties(
-            ImmutableSet.copyOf(GCS_TRACE_LOG_EXCLUDE_PROPERTIES.getStringCollection(config)));
+            ImmutableSet.copyOf(GCS_TRACE_LOG_EXCLUDE_PROPERTIES.getStringCollection(config)))
+        .setStorageClientCachingExperimentEnabled(GCS_STORAGE_CLIENT_CACHING_EXPERIMENT.get(config, config::getBoolean));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -154,6 +154,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
               "fs.gs.write.parallel.composite.upload.part.file.cleanup.type",
               PartFileCleanupType.ALWAYS);
           put("fs.gs.write.parallel.composite.upload.part.file.name.prefix", "");
+          put("fs.gs.client.caching.experiment.enabled", false);
         }
       };
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -151,10 +151,13 @@ public abstract class GoogleCloudStorageOptions {
         .setTraceLogTimeThreshold(0)
         .setTraceLogExcludeProperties(ImmutableSet.of())
         .setHnBucketRenameEnabled(SET_HN_BUCKET_CREATE_ENABLED_DEFAULT)
-        .setGrpcWriteEnabled(GRPC_WRITE_DEFAULT);
+        .setGrpcWriteEnabled(GRPC_WRITE_DEFAULT)
+        .setStorageClientCachingExperimentEnabled(false);
   }
 
   public abstract Builder toBuilder();
+
+  public abstract boolean isStorageClientCachingExperimentEnabled();
 
   public abstract boolean isGrpcEnabled();
 
@@ -347,6 +350,8 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setTraceLogExcludeProperties(ImmutableSet<String> properties);
 
     public abstract Builder setGrpcWriteEnabled(boolean grpcWriteEnabled);
+
+    public abstract Builder setStorageClientCachingExperimentEnabled(boolean isExperimentEnabled);
 
     abstract GoogleCloudStorageOptions autoBuild();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageProvider.java
@@ -1,0 +1,184 @@
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl.*;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.hadoop.util.AccessBoundary;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.flogger.GoogleLogger;
+import io.grpc.ClientInterceptor;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Provides GCS SDK Storage object which is used to access the GCS. Also Caches the storage objects,
+ * so they can be used re-used.
+ */
+public class StorageProvider {
+
+  @VisibleForTesting
+  final Cache<StorageProviderCacheKey, Storage> cache =
+      CacheBuilder.newBuilder().recordStats().build();
+
+  /** Tracks the number of times a storage client is used. */
+  @VisibleForTesting
+  final Map<Storage, Integer> storageClientToReferenceMap = new ConcurrentHashMap<>();
+
+  /** Reverse map for storage reference to cache keys. */
+  final Map<Storage, StorageProviderCacheKey> storageToCacheKeyMap = new ConcurrentHashMap<>();
+
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  @VisibleForTesting
+  StorageProviderCacheKey computeCacheKey(
+      Credentials credentials,
+      GoogleCloudStorageOptions storageOptions,
+      Function<List<AccessBoundary>, String> downscopedAccessTokenFn) {
+    return StorageProviderCacheKey.builder()
+        .setCredentials(credentials)
+        .setHttpHeaders(storageOptions.getHttpRequestHeaders())
+        .setIsDirectPathPreferred(storageOptions.isDirectPathPreferred())
+        .setIsDownScopingEnabled(downscopedAccessTokenFn != null)
+        .setIsTracingEnabled(storageOptions.isTraceLogEnabled())
+        .setWriteChannelOptions(storageOptions.getWriteChannelOptions())
+        .build();
+  }
+
+  /** Determines if the storage instance can be served from the cache. */
+  private static boolean canCache(
+      GoogleCloudStorageOptions options,
+      List<ClientInterceptor> interceptors,
+      ExecutorService pCUExecutorService) {
+
+    return options.isStorageClientCachingExperimentEnabled()
+        // These values are currently passed while creating the storage client, but they are
+        // currently not configurable by the FS options so skipping caching.
+        && pCUExecutorService == null
+        && (interceptors == null || interceptors.isEmpty());
+  }
+
+  Storage getStorage(
+      Credentials credentials,
+      GoogleCloudStorageOptions storageOptions,
+      List<ClientInterceptor> interceptors,
+      ExecutorService pCUExecutorService,
+      Function<List<AccessBoundary>, String> downscopedAccessTokenFn)
+      throws IOException {
+    if (canCache(storageOptions, interceptors, pCUExecutorService)) {
+      StorageProviderCacheKey key =
+          computeCacheKey(credentials, storageOptions, downscopedAccessTokenFn);
+      Storage storage = cache.getIfPresent(key);
+      if (storage == null) {
+        storage = createStorage(credentials, storageOptions, null, null, downscopedAccessTokenFn);
+        cache.put(key, storage);
+        storageToCacheKeyMap.put(storage, key);
+        logger.atFinest().log("Cache miss, created new storage client. Cache hit count : %d, Cache hit rate : %d", cache.stats().hitCount(), cache.stats().hitRate());
+      } else {
+        logger.atFinest().log("Cache hit, reusing the storage client. Cache hit count : %d, Cache hit rate : %d", cache.stats().hitCount(), cache.stats().hitRate());
+      }
+      // Increment the reference count of the storage object.
+      storageClientToReferenceMap.put(
+          storage, storageClientToReferenceMap.getOrDefault(storage, 0) + 1);
+      return storage;
+    }
+    return createStorage(
+        credentials, storageOptions, interceptors, pCUExecutorService, downscopedAccessTokenFn);
+  }
+
+  private static Storage createStorage(
+      Credentials credentials,
+      GoogleCloudStorageOptions storageOptions,
+      List<ClientInterceptor> interceptors,
+      ExecutorService pCUExecutorService,
+      Function<List<AccessBoundary>, String> downscopedAccessTokenFn)
+      throws IOException {
+    final ImmutableMap<String, String> headers = getUpdatedHeadersWithUserAgent(storageOptions);
+
+    return StorageOptions.grpc()
+        .setAttemptDirectPath(storageOptions.isDirectPathPreferred())
+        .setHeaderProvider(() -> headers)
+        .setGrpcInterceptorProvider(
+            () -> {
+              List<ClientInterceptor> list = new ArrayList<>();
+              if (interceptors != null && !interceptors.isEmpty()) {
+                list.addAll(
+                    interceptors.stream().filter(x -> x != null).collect(Collectors.toList()));
+              }
+              if (storageOptions.isTraceLogEnabled()) {
+                list.add(new GoogleCloudStorageClientGrpcTracingInterceptor());
+              }
+
+              if (downscopedAccessTokenFn != null) {
+                // When downscoping is enabled, we need to set the downscoped token for each
+                // request. In the case of gRPC, the downscoped token will be set from the
+                // Interceptor.
+                list.add(
+                    new GoogleCloudStorageClientGrpcDownscopingInterceptor(
+                        downscopedAccessTokenFn));
+              }
+
+              list.add(new GoogleCloudStorageClientGrpcStatisticsInterceptor());
+              return ImmutableList.copyOf(list);
+            })
+        .setCredentials(
+            credentials != null ? credentials : getNoCredentials(downscopedAccessTokenFn))
+        .setBlobWriteSessionConfig(
+            getSessionConfig(storageOptions.getWriteChannelOptions(), pCUExecutorService))
+        .setProjectId(storageOptions.getProjectId())
+        .build()
+        .getService();
+  }
+
+  private static Credentials getNoCredentials(
+      Function<List<AccessBoundary>, String> downscopedAccessTokenFn) {
+    if (downscopedAccessTokenFn == null) {
+      return null;
+    }
+
+    // Workaround for https://github.com/googleapis/sdk-platform-java/issues/2356. Once this is
+    // fixed, change this to return NoCredentials.getInstance();
+    return GoogleCredentials.create(new AccessToken("", null));
+  }
+
+  private void closeStorage(Storage storage) {
+    try {
+      storage.close();
+    } catch (Exception e) {
+      logger.atWarning().withCause(e).log("Error occurred while closing the storage client");
+    }
+  }
+
+  /**
+   * Signal the storage object to be closed. The resources held by the storage object will be freed
+   * only if the instance is closed by all the objects sharing this storage reference.
+   */
+  void close(Storage storage) {
+    if (storageClientToReferenceMap.containsKey(storage)) {
+      int referenceCount = storageClientToReferenceMap.get(storage);
+      // Decrement the reference count of the object.
+      storageClientToReferenceMap.put(storage, referenceCount - 1);
+      if (referenceCount - 1 == 0) {
+        StorageProviderCacheKey key = storageToCacheKeyMap.get(storage);
+        cache.invalidate(key);
+        storageToCacheKeyMap.remove(storage);
+        closeStorage(storage);
+      }
+    } else {
+      closeStorage(storage);
+    }
+  }
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageProviderCacheKey.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageProviderCacheKey.java
@@ -1,0 +1,57 @@
+package com.google.cloud.hadoop.gcsio;
+
+import com.google.auth.Credentials;
+import com.google.auto.value.AutoValue;
+import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.common.collect.ImmutableMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class StorageProviderCacheKey {
+
+  public static StorageProviderCacheKey.Builder builder() {
+    return new AutoValue_StorageProviderCacheKey.Builder();
+  }
+
+  /** Whether tracing is requested. */
+  public abstract boolean getIsTracingEnabled();
+
+  /** Credentials to use for the GCS client, otherwise null. */
+  @Nullable
+  public abstract Credentials getCredentials();
+
+  /** Whether downscoped tokens are used for authenticating with the GCS backend. */
+  public abstract boolean getIsDownScopingEnabled();
+
+  @Nullable
+  public abstract ImmutableMap<String, String> getHttpHeaders();
+
+  @Nullable
+  public abstract AsyncWriteChannelOptions getWriteChannelOptions();
+
+  @Nullable
+  public abstract String getProjectId();
+
+  public abstract boolean getIsDirectPathPreferred();
+
+  public abstract StorageProviderCacheKey.Builder toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setIsTracingEnabled(boolean value);
+
+    public abstract Builder setCredentials(Credentials value);
+
+    public abstract Builder setIsDownScopingEnabled(boolean value);
+
+    public abstract Builder setHttpHeaders(ImmutableMap<String, String> value);
+
+    public abstract Builder setWriteChannelOptions(AsyncWriteChannelOptions value);
+
+    public abstract Builder setProjectId(String value);
+
+    public abstract Builder setIsDirectPathPreferred(boolean value);
+
+    public abstract StorageProviderCacheKey build();
+  }
+}

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageJavaStorageClientCachingIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageJavaStorageClientCachingIntegrationTest.java
@@ -1,18 +1,11 @@
 package com.google.cloud.hadoop.gcsio;
 
 import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getCredential;
-import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getCredentials;
 import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getStandardOptionBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import com.google.api.services.storage.StorageScopes;
-import com.google.auth.Credentials;
-import com.google.auth.oauth2.ComputeEngineCredentials;
-import com.google.auth.oauth2.ServiceAccountCredentials;
-import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
 import com.google.common.collect.ImmutableMap;
-import java.io.FileInputStream;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import org.junit.Test;
@@ -21,7 +14,7 @@ import org.junit.runners.JUnit4;
 
 /** Tests for GoogleCloudStorageClientImpl caching experiment. */
 @RunWith(JUnit4.class)
-public class GoogleCloudStorageJavaStorageClientCachingTest {
+public class GoogleCloudStorageJavaStorageClientCachingIntegrationTest {
 
   @Test
   public void reusesCachedStorageClient_experimentEnabled() throws IOException {
@@ -61,18 +54,8 @@ public class GoogleCloudStorageJavaStorageClientCachingTest {
     return GoogleCloudStorageClientImpl.builder()
         .setOptions(optionsBuilder.build())
         .setCredential(getCredential())
-        .setCredentials(getCredentials())
+        .setCredentials(null)
+        .setDownscopedAccessTokenFn(ignore -> "testDownscopedAccessToken")
         .build();
-  }
-
-  public static Credentials getCredentials() throws IOException {
-    String serviceAccountJsonKeyFile =
-        TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
-    if (serviceAccountJsonKeyFile == null) {
-      return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
-    }
-    try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
-      return ServiceAccountCredentials.fromStream(fis).createScoped(StorageScopes.CLOUD_PLATFORM);
-    }
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageJavaStorageClientCachingTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageJavaStorageClientCachingTest.java
@@ -1,0 +1,78 @@
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getCredential;
+import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getCredentials;
+import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getStandardOptionBuilder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import com.google.api.services.storage.StorageScopes;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
+import com.google.common.collect.ImmutableMap;
+import java.io.FileInputStream;
+import java.io.IOException;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for GoogleCloudStorageClientImpl caching experiment. */
+@RunWith(JUnit4.class)
+public class GoogleCloudStorageJavaStorageClientCachingTest {
+
+  @Test
+  public void reusesCachedStorageClient_experimentEnabled() throws IOException {
+    GoogleCloudStorageClientImpl test_gcs1 = createGcsClient(null, true);
+    GoogleCloudStorageClientImpl test_gcs2 = createGcsClient(null, true);
+
+    assertEquals(test_gcs1.storage, test_gcs2.storage);
+  }
+
+  @Test
+  public void createsNewClient_experimentEnabled() throws IOException {
+    GoogleCloudStorageOptions.Builder testOptionsBuilder =
+        getStandardOptionBuilder()
+            .setTraceLogEnabled(true)
+            .setHttpRequestHeaders((ImmutableMap.of("header-key", "header-value")));
+    GoogleCloudStorageClientImpl test_gcs1 = createGcsClient(testOptionsBuilder, true);
+    GoogleCloudStorageClientImpl test_gcs2 = createGcsClient(null, true);
+
+    assertNotEquals(test_gcs1.storage, test_gcs2.storage);
+  }
+
+  @Test
+  public void createsNewClient_experimentDisabled() throws IOException {
+    GoogleCloudStorageClientImpl test_gcs1 = createGcsClient(null, false);
+    GoogleCloudStorageClientImpl test_gcs2 = createGcsClient(null, false);
+
+    assertNotEquals(test_gcs1.storage, test_gcs2.storage);
+  }
+
+  private GoogleCloudStorageClientImpl createGcsClient(
+      @Nullable GoogleCloudStorageOptions.Builder optionsBuilder, boolean enableCachingExperiment)
+      throws IOException {
+    if (optionsBuilder == null) {
+      optionsBuilder = getStandardOptionBuilder();
+    }
+    optionsBuilder.setStorageClientCachingExperimentEnabled(enableCachingExperiment);
+    return GoogleCloudStorageClientImpl.builder()
+        .setOptions(optionsBuilder.build())
+        .setCredential(getCredential())
+        .setCredentials(getCredentials())
+        .build();
+  }
+
+  public static Credentials getCredentials() throws IOException {
+    String serviceAccountJsonKeyFile =
+        TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
+    if (serviceAccountJsonKeyFile == null) {
+      return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
+    }
+    try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
+      return ServiceAccountCredentials.fromStream(fis).createScoped(StorageScopes.CLOUD_PLATFORM);
+    }
+  }
+}

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/StorageProviderTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/StorageProviderTest.java
@@ -1,0 +1,151 @@
+package com.google.cloud.hadoop.gcsio;
+
+import static org.junit.Assert.*;
+
+import com.google.auth.Credentials;
+import com.google.cloud.hadoop.util.AccessBoundary;
+import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.cloud.storage.Storage;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class StorageProviderTest {
+
+  private static final Credentials TEST_CREDENTIALS = null;
+
+  private static final GoogleCloudStorageOptions TEST_STORAGE_OPTIONS =
+      GoogleCloudStorageOptions.builder()
+          .setHttpRequestHeaders((ImmutableMap.of("header-key", "header-value")))
+          .setProjectId("test-project")
+          .setTraceLogEnabled(true)
+          .setDirectPathPreferred(true)
+          .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
+          .setStorageClientCachingExperimentEnabled(true)
+          .build();
+
+  private static final Function<List<AccessBoundary>, String> TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC =
+      (accessBoundaries) -> "token";
+
+  private StorageProvider storageProvider;
+
+  /** Returns number of times a storage object in cache is referenced among different clients. */
+  private int getReferences(Storage storage) {
+    return storageProvider.storageClientToReferenceMap.getOrDefault(storage, 0);
+  }
+
+  @Before
+  public void setUp() {
+    storageProvider = new StorageProvider();
+  }
+
+  @Test
+  public void getStorage_returnsAndCachesNewStorageObject() throws IOException {
+    Storage storage =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS, TEST_STORAGE_OPTIONS, null, null, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+
+    assertNotNull(storage);
+    assertEquals(storageProvider.cache.size(), 1);
+
+    Storage cachedStorage =
+        storageProvider.cache.getIfPresent(
+            storageProvider.computeCacheKey(
+                TEST_CREDENTIALS, TEST_STORAGE_OPTIONS, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC));
+    assertNotNull(cachedStorage);
+    assertEquals(storage, cachedStorage);
+  }
+
+  @Test
+  public void getStorage_experimentDisabled_doesNotCache() throws IOException {
+    GoogleCloudStorageOptions disableExperimentOptions =
+        TEST_STORAGE_OPTIONS.toBuilder().setStorageClientCachingExperimentEnabled(false).build();
+    Storage storage =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS,
+            disableExperimentOptions,
+            null,
+            null,
+            TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+
+    assertNotNull(storage);
+    assertEquals(storageProvider.cache.size(), 0);
+  }
+
+  @Test
+  public void getStorage_returnsCachedStorageObject() throws IOException {
+    Storage storage1 =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS, TEST_STORAGE_OPTIONS, null, null, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+    Storage storage2 =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS, TEST_STORAGE_OPTIONS, null, null, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+
+    assertEquals(storageProvider.cache.size(), 1);
+    // A single storage object should be shared across both the references.
+    assertEquals(getReferences(storage1), 2);
+    assertEquals(storage1, storage2);
+  }
+
+  @Test
+  public void getStorage_cacheMiss_returnsNewObject() throws Exception {
+    GoogleCloudStorageOptions testOptions =
+        TEST_STORAGE_OPTIONS.toBuilder()
+            .setTraceLogEnabled(false)
+            .setDirectPathPreferred(false)
+            .build();
+
+    Storage storage1 =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS, TEST_STORAGE_OPTIONS, null, null, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+    Storage storage2 =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS, testOptions, null, null, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+
+    assertNotEquals(storage1, storage2);
+    assertEquals(getReferences(storage1), 1);
+    assertEquals(getReferences(storage2), 1);
+  }
+
+  @Test
+  public void close_nonZeroReference_doesNotCloseObject() throws Exception {
+    Storage storage1 =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS, TEST_STORAGE_OPTIONS, null, null, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+    Storage storage2 =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS, TEST_STORAGE_OPTIONS, null, null, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+
+    assertEquals(storageProvider.cache.size(), 1);
+    // A single storage object should be shared across both the references.
+    assertEquals(getReferences(storage1), 2);
+    assertEquals(storage1, storage2);
+
+    storageProvider.close(storage1);
+    // Item is not removed from the cache but the reference is reduced.
+    assertEquals(storageProvider.cache.size(), 1);
+    assertEquals(getReferences(storage1), 1);
+  }
+
+  @Test
+  public void close_zeroReference_closesStorageObject() throws Exception {
+    Storage storage1 =
+        storageProvider.getStorage(
+            TEST_CREDENTIALS, TEST_STORAGE_OPTIONS, null, null, TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+
+    assertEquals(storageProvider.cache.size(), 1);
+    // A single storage object should be shared across both the references.
+    assertEquals(getReferences(storage1), 1);
+
+    storageProvider.close(storage1);
+    // Item is removed from the cache.
+    assertEquals(storageProvider.cache.size(), 0);
+    assertEquals(getReferences(storage1), 0);
+  }
+}

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/StorageProviderTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/StorageProviderTest.java
@@ -96,7 +96,8 @@ public class StorageProviderTest {
   @Test
   public void getStorage_cacheMiss_returnsNewObject() throws Exception {
     GoogleCloudStorageOptions testOptions =
-        TEST_STORAGE_OPTIONS.toBuilder()
+        TEST_STORAGE_OPTIONS
+            .toBuilder()
             .setTraceLogEnabled(false)
             .setDirectPathPreferred(false)
             .build();
@@ -147,5 +148,6 @@ public class StorageProviderTest {
     // Item is removed from the cache.
     assertEquals(storageProvider.cache.size(), 0);
     assertEquals(getReferences(storage1), 0);
+    assertFalse(storageProvider.storageClientToReferenceMap.containsKey(storage1));
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/StorageProviderTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/StorageProviderTest.java
@@ -9,8 +9,17 @@ import com.google.cloud.storage.Storage;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -23,7 +32,6 @@ public class StorageProviderTest {
   private static final GoogleCloudStorageOptions TEST_STORAGE_OPTIONS =
       GoogleCloudStorageOptions.builder()
           .setHttpRequestHeaders((ImmutableMap.of("header-key", "header-value")))
-          .setProjectId("test-project")
           .setTraceLogEnabled(true)
           .setDirectPathPreferred(true)
           .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
@@ -33,11 +41,33 @@ public class StorageProviderTest {
   private static final Function<List<AccessBoundary>, String> TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC =
       (accessBoundaries) -> "token";
 
+  private static final String TEST_PROJECT_PREFIX = "test-project";
+
+  private static final String PROJECT_ENV_VARIABLE = "GOOGLE_CLOUD_PROJECT";
+
   private StorageProvider storageProvider;
+
+  private static String testProject = null;
 
   /** Returns number of times a storage object in cache is referenced among different clients. */
   private int getReferences(Storage storage) {
     return storageProvider.storageClientToReferenceMap.getOrDefault(storage, 0);
+  }
+
+  @BeforeClass
+  public static void beforeClass() {
+    if (System.getProperty(PROJECT_ENV_VARIABLE) == null) {
+      // Project id is required for storage instantiation.
+      testProject = TEST_PROJECT_PREFIX + UUID.randomUUID();
+      System.setProperty(PROJECT_ENV_VARIABLE, testProject);
+    }
+  }
+
+  @AfterClass
+  public static void afterCLass() {
+    if (Objects.equals(System.getProperty(PROJECT_ENV_VARIABLE), testProject)) {
+      System.clearProperty(PROJECT_ENV_VARIABLE);
+    }
   }
 
   @Before
@@ -149,5 +179,38 @@ public class StorageProviderTest {
     assertEquals(storageProvider.cache.size(), 0);
     assertEquals(getReferences(storage1), 0);
     assertFalse(storageProvider.storageClientToReferenceMap.containsKey(storage1));
+  }
+
+  @Test
+  public void getStorageConcurrent_returnsStorage() throws Exception {
+    int numThreads = 100;
+    ExecutorService executorService = Executors.newFixedThreadPool(100);
+    final CountDownLatch latch = new CountDownLatch(numThreads);
+
+    AtomicInteger failures = new AtomicInteger();
+    for (int i = 0; i < numThreads; i++) {
+      executorService.submit(
+          () -> {
+            try {
+              storageProvider.getStorage(
+                  TEST_CREDENTIALS,
+                  TEST_STORAGE_OPTIONS,
+                  null,
+                  null,
+                  TEST_DOWNSCOPED_ACCESS_TOKEN_FUNC);
+            } catch (IOException e) {
+              failures.getAndIncrement();
+            } finally {
+              latch.countDown();
+            }
+          });
+    }
+
+    boolean isComplete = latch.await(5000, TimeUnit.MILLISECONDS);
+    executorService.shutdown();
+    if (failures.get() > 0 || !isComplete) {
+      fail("Storage creation failed");
+    }
+    assertEquals(storageProvider.cache.size(), 1);
   }
 }


### PR DESCRIPTION
Facilitate sharing GCS grpc SDK client across multiple filesystems based on combination of credentials, downscoped tokens and storage options.