### PR TITLE
upgrade gcs SDK to 2.45.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,19 +89,19 @@
     <google.api-bigquery.version>v2-rev20221028-${google.api-client-libraries.version}</google.api-bigquery.version>
     <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
     <google.api-storage.version>v1-rev20240105-${google.api-client-libraries.version}</google.api-storage.version>
-    <google.auth.version>1.29.0</google.auth.version>
+    <google.auth.version>1.30.0</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <google.cloud-bigquerystorage.version>2.39.1</google.cloud-bigquerystorage.version>
     <google.cloud-core.version>2.44.1</google.cloud-core.version>
-    <google.cloud-storage.bom.version>2.44.1</google.cloud-storage.bom.version>
+    <google.cloud-storage.bom.version>2.45.0</google.cloud-storage.bom.version>
     <google.flogger.version>0.7.1</google.flogger.version>
-    <google.gax.version>2.54.1</google.gax.version>
+    <google.gax.version>2.58.0</google.gax.version>
     <google.gson.version>2.8.9</google.gson.version>
     <google.guava.version>33.1.0-jre</google.guava.version>
     <google.http-client.version>1.42.3</google.http-client.version>
     <google.oauth-client.version>1.34.1</google.oauth-client.version>
     <google.protobuf.version>3.25.3</google.protobuf.version>
-    <grpc.version>1.67.1</grpc.version>
+    <grpc.version>1.68.1</grpc.version>
     <hadoop.two.version>2.10.2</hadoop.two.version>
     <hadoop.three.version>3.2.4</hadoop.three.version>
     <opencensus.version>0.31.0</opencensus.version>


### PR DESCRIPTION
Upgrade GCS SDK to 2.45.0

- Had to upgrade GAX Java to 2.58.0 because of change in `InstantiatingGrpcChannelProvider`
- Had to upgrade Google Auth to 1.30.0 because of dependency on class `SecureSessionAgent`
- Had to upgrade grpc version to 1.68.1 because of version conflicts.